### PR TITLE
refactor `raw_menu_anchor.dart`

### DIFF
--- a/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor.0_test.dart
+++ b/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor.0_test.dart
@@ -17,7 +17,7 @@ T findMenuPanelDescendent<T extends Widget>(WidgetTester tester) {
 }
 
 Finder findMenuPanel() {
-  return find.byType(RawMenuAnchor.debugMenuOverlayPanelType);
+  return find.byKey(RawMenuAnchor.debugMenuOverlayPanelKey);
 }
 
 List<Rect> collectOverlays({bool clipped = true}) {

--- a/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor.1_test.dart
+++ b/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor.1_test.dart
@@ -20,7 +20,7 @@ T findMenuPanelDescendent<T extends Widget>(WidgetTester tester) {
 }
 
 Finder findMenuPanel() {
-  return find.byType(RawMenuAnchor.debugMenuOverlayPanelType);
+  return find.byKey(RawMenuAnchor.debugMenuOverlayPanelKey);
 }
 
 List<Rect> collectOverlays({bool clipped = true}) {

--- a/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor.3_test.dart
+++ b/examples/api/test/widgets/raw_menu_anchor/raw_menu_anchor.3_test.dart
@@ -17,7 +17,7 @@ T findMenuPanelDescendent<T extends Widget>(WidgetTester tester) {
 }
 
 Finder findMenuPanel() {
-  return find.byType(RawMenuAnchor.debugMenuOverlayPanelType);
+  return find.byKey(RawMenuAnchor.debugMenuOverlayPanelKey);
 }
 
 void main() {

--- a/packages/flutter/test/widgets/raw_menu_anchor_test.dart
+++ b/packages/flutter/test/widgets/raw_menu_anchor_test.dart
@@ -64,7 +64,7 @@ void main() {
   }
 
   Finder findMenuPanel() {
-    return find.byType(RawMenuAnchor.debugMenuOverlayPanelType);
+    return find.byKey(RawMenuAnchor.debugMenuOverlayPanelKey);
   }
 
   Finder findOverlayContents() {
@@ -5654,7 +5654,7 @@ class NestedTag extends Tag {
     if (level == 0 || _prefix == null) {
       return _name;
     }
-    return '${_prefix!.text}.$_name';
+    return '${_prefix.text}.$_name';
   }
 
   @override


### PR DESCRIPTION
I know it's a bit weird to be making a PR to merge into your fork… I had what one might call a "Vyvanse-fueled fever dream" over the weekend and tried cleaning up the class structure in raw_menu_anchor.dart a bit.

I was able to consolidate a few classes and reduced the lines of code from 1998 to 1778 :)